### PR TITLE
Routing from localhost:4001 to port 5432

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,8 @@ services:
     image: postgres:14.5-alpine
     environment:
       POSTGRES_PASSWORD: password
+    ports:
+      - 4001:5432
     volumes:
       - database-content:/var/lib/postgresql/data
     expose:


### PR DESCRIPTION
Hello,
J'ai ajouté la possibilité d’accéder à la base de donnée via le port localhost:4001 si on veut utilisé un autre client que adminer.